### PR TITLE
docs: correct overwrite short flag to -O in USAGE

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -69,7 +69,7 @@
   Adds a suffix to the output filename, before the file extension.
 - `-S, --keep-structure`  
   Preserves the folder tree structure of the input files. Can be used only with `-R`.
-- `-o, --overwrite <OVERWRITE>`  
+- `-O, --overwrite <OVERWRITE>`  
   Sets the overwrite policy if the output file already exists. Possible values are:
     - `all`: Always overwrite
     - `never`: Never overwrite


### PR DESCRIPTION
The USAGE docs list the overwrite option with the short flag `-o`, but `-o` is already the short flag for `--output`. The overwrite option's real short flag is `-O` (uppercase), defined in `src/options.rs` (`#[arg(short = 'O', ...)] pub overwrite`), and the README examples use it (`caesiumclt -q 85 -O never ...`).

As written, copying `-o never` from the docs fails with an invalid value for `--output`. This corrects the documented flag to `-O`.
